### PR TITLE
Fix Crash without Input Mod

### DIFF
--- a/idle-chatter/idle-chatter.cpp
+++ b/idle-chatter/idle-chatter.cpp
@@ -9,7 +9,7 @@ extern "C"
 	{
 		for (uint8_t i = 0; i < pMax; i++)
 		{
-			if (ControllerPointers[i]->PressedButtons & Buttons_Z)
+			if (Controllers[i].PressedButtons & Buttons_Z)
 			{
 				CharObj2* player = GetCharObj2(i);
 

--- a/idle-chatter/mod.ini
+++ b/idle-chatter/mod.ini
@@ -1,6 +1,6 @@
 Name=Idle Chatter
 Description=Press Z to hear what your character has to say about the stage!
-Version=1.2
+Version=1.3
 Author=SonicFreak94
 DLLFile=idle-chatter-sadx.dll
 GitHubRepo=michael-fadely/sadx-idle-chatter


### PR DESCRIPTION
See previous PR: If you have Idle Chatter enabled but not Input Mod, the game will crash on startup while looking at the ControllerPointers array. Might be a pointer null? Either way, I swapped for the regular Controllers array which is what it should have used originally.
